### PR TITLE
Replace Vcash references with Pila

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -4,7 +4,7 @@
 
 - [ ] I have tried with the latest version and I still can reproduce the issue.
 
-##### Vcash version/branch+revision: #####
+##### Pila version/branch+revision: #####
 
 ##### Operating system and version: #####
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ V(anilla)cash
 
 A decentralized currency for the internet.
 
-[![Gitter](https://badges.gitter.im/openvcash/vcash.svg)](https://gitter.im/openvcash/vcash?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+[![Gitter](https://badges.gitter.im/cryptopila/pila.svg)](https://gitter.im/cryptopila/pila?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
 This project is a codebase rewrite/enhancment using:
 * [Peercoin](https://github.com/ppcoin/ppcoin) PoS & [Bitcoin](https://github.com/bitcoin/bitcoin) PoW consensus
@@ -19,4 +19,4 @@ Dependencies:
 * Berkeley DB == 6.1.29.NC
 * OpenSSL == 1.0.2k
 
-Linux: use https://github.com/openvcash/vcash-scripts
+Linux: use https://github.com/cryptopila/pila-scripts

--- a/coin/include/coin/account.hpp
+++ b/coin/include/coin/account.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/accounting_entry.hpp
+++ b/coin/include/coin/accounting_entry.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/address.hpp
+++ b/coin/include/coin/address.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/address_manager.hpp
+++ b/coin/include/coin/address_manager.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/alert.hpp
+++ b/coin/include/coin/alert.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/alert_manager.hpp
+++ b/coin/include/coin/alert_manager.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/alert_unsigned.hpp
+++ b/coin/include/coin/alert_unsigned.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/android.hpp
+++ b/coin/include/coin/android.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/base58.hpp
+++ b/coin/include/coin/base58.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/big_number.hpp
+++ b/coin/include/coin/big_number.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/blake256.hpp
+++ b/coin/include/coin/blake256.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/block.hpp
+++ b/coin/include/coin/block.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/block_index.hpp
+++ b/coin/include/coin/block_index.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/block_index_disk.hpp
+++ b/coin/include/coin/block_index_disk.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/block_locator.hpp
+++ b/coin/include/coin/block_locator.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/block_merkle.hpp
+++ b/coin/include/coin/block_merkle.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/block_orphan.hpp
+++ b/coin/include/coin/block_orphan.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/chainblender.hpp
+++ b/coin/include/coin/chainblender.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/chainblender_broadcast.hpp
+++ b/coin/include/coin/chainblender_broadcast.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/chainblender_join.hpp
+++ b/coin/include/coin/chainblender_join.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/chainblender_leave.hpp
+++ b/coin/include/coin/chainblender_leave.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/chainblender_manager.hpp
+++ b/coin/include/coin/chainblender_manager.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/chainblender_status.hpp
+++ b/coin/include/coin/chainblender_status.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/checkpoint_sync.hpp
+++ b/coin/include/coin/checkpoint_sync.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/checkpoint_sync_unsigned.hpp
+++ b/coin/include/coin/checkpoint_sync_unsigned.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/checkpoints.hpp
+++ b/coin/include/coin/checkpoints.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/coin_control.hpp
+++ b/coin/include/coin/coin_control.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/configuration.hpp
+++ b/coin/include/coin/configuration.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/constants.hpp
+++ b/coin/include/coin/constants.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)
@@ -76,7 +76,7 @@ namespace constants {
     /**
      * The name of the coin.
      */
-    static const std::string client_name = "Vcash";
+    static const std::string client_name = "Pila";
 
     /**
      * A coin.

--- a/coin/include/coin/crypter.hpp
+++ b/coin/include/coin/crypter.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/crypto.hpp
+++ b/coin/include/coin/crypto.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/data_buffer.hpp
+++ b/coin/include/coin/data_buffer.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/database_stack.hpp
+++ b/coin/include/coin/database_stack.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/db.hpp
+++ b/coin/include/coin/db.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/db_env.hpp
+++ b/coin/include/coin/db_env.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/db_tx.hpp
+++ b/coin/include/coin/db_tx.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/db_tx_bdb.hpp
+++ b/coin/include/coin/db_tx_bdb.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/db_tx_ldb.hpp
+++ b/coin/include/coin/db_tx_ldb.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/db_wallet.hpp
+++ b/coin/include/coin/db_wallet.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/destination.hpp
+++ b/coin/include/coin/destination.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/ecdhe.h
+++ b/coin/include/coin/ecdhe.h
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/ecdhe.hpp
+++ b/coin/include/coin/ecdhe.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/endian.hpp
+++ b/coin/include/coin/endian.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/file.hpp
+++ b/coin/include/coin/file.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/filesystem.hpp
+++ b/coin/include/coin/filesystem.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/gateway.hpp
+++ b/coin/include/coin/gateway.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/globals.hpp
+++ b/coin/include/coin/globals.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/hash.hpp
+++ b/coin/include/coin/hash.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/hc256.hpp
+++ b/coin/include/coin/hc256.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/hd_configuration.hpp
+++ b/coin/include/coin/hd_configuration.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/hd_ecdsa.hpp
+++ b/coin/include/coin/hd_ecdsa.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/hd_keychain.hpp
+++ b/coin/include/coin/hd_keychain.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/http_transport.hpp
+++ b/coin/include/coin/http_transport.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/incentive.hpp
+++ b/coin/include/coin/incentive.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/incentive_answer.hpp
+++ b/coin/include/coin/incentive_answer.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/incentive_collaterals.hpp
+++ b/coin/include/coin/incentive_collaterals.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/incentive_manager.hpp
+++ b/coin/include/coin/incentive_manager.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/incentive_question.hpp
+++ b/coin/include/coin/incentive_question.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/incentive_sync.hpp
+++ b/coin/include/coin/incentive_sync.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/incentive_vote.hpp
+++ b/coin/include/coin/incentive_vote.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/inventory_vector.hpp
+++ b/coin/include/coin/inventory_vector.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/kernel.hpp
+++ b/coin/include/coin/kernel.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/key.hpp
+++ b/coin/include/coin/key.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/key_pool.hpp
+++ b/coin/include/coin/key_pool.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/key_public.hpp
+++ b/coin/include/coin/key_public.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/key_reserved.hpp
+++ b/coin/include/coin/key_reserved.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/key_store.hpp
+++ b/coin/include/coin/key_store.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/key_store_basic.hpp
+++ b/coin/include/coin/key_store_basic.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/key_store_crypto.hpp
+++ b/coin/include/coin/key_store_crypto.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/key_wallet.hpp
+++ b/coin/include/coin/key_wallet.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/key_wallet_master.hpp
+++ b/coin/include/coin/key_wallet_master.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/logger.hpp
+++ b/coin/include/coin/logger.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/median_filter.hpp
+++ b/coin/include/coin/median_filter.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/merkle_tree_partial.hpp
+++ b/coin/include/coin/merkle_tree_partial.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/message.hpp
+++ b/coin/include/coin/message.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/mining.hpp
+++ b/coin/include/coin/mining.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/mining_manager.hpp
+++ b/coin/include/coin/mining_manager.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/nat_pmp.hpp
+++ b/coin/include/coin/nat_pmp.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/nat_pmp_client.hpp
+++ b/coin/include/coin/nat_pmp_client.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/network.hpp
+++ b/coin/include/coin/network.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/output.hpp
+++ b/coin/include/coin/output.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/pbkdf2.hpp
+++ b/coin/include/coin/pbkdf2.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/point_in.hpp
+++ b/coin/include/coin/point_in.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/point_out.hpp
+++ b/coin/include/coin/point_out.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/protocol.hpp
+++ b/coin/include/coin/protocol.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/random.hpp
+++ b/coin/include/coin/random.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/reward.hpp
+++ b/coin/include/coin/reward.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/ripemd160.hpp
+++ b/coin/include/coin/ripemd160.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/rpc_connection.hpp
+++ b/coin/include/coin/rpc_connection.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/rpc_json_parser.hpp
+++ b/coin/include/coin/rpc_json_parser.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/rpc_manager.hpp
+++ b/coin/include/coin/rpc_manager.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/rpc_server.hpp
+++ b/coin/include/coin/rpc_server.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/rpc_transport.hpp
+++ b/coin/include/coin/rpc_transport.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/script.hpp
+++ b/coin/include/coin/script.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/script_checker.hpp
+++ b/coin/include/coin/script_checker.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/script_checker_queue.hpp
+++ b/coin/include/coin/script_checker_queue.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/secret.hpp
+++ b/coin/include/coin/secret.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/sha256.hpp
+++ b/coin/include/coin/sha256.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/signature_cache.hpp
+++ b/coin/include/coin/signature_cache.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/stack.hpp
+++ b/coin/include/coin/stack.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/stack_impl.hpp
+++ b/coin/include/coin/stack_impl.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/status_manager.hpp
+++ b/coin/include/coin/status_manager.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/tcp_acceptor.hpp
+++ b/coin/include/coin/tcp_acceptor.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/tcp_connection.hpp
+++ b/coin/include/coin/tcp_connection.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/tcp_connection_manager.hpp
+++ b/coin/include/coin/tcp_connection_manager.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/tcp_transport.hpp
+++ b/coin/include/coin/tcp_transport.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/time.hpp
+++ b/coin/include/coin/time.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/transaction.hpp
+++ b/coin/include/coin/transaction.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/transaction_bloom_filter.hpp
+++ b/coin/include/coin/transaction_bloom_filter.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/transaction_in.hpp
+++ b/coin/include/coin/transaction_in.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/transaction_index.hpp
+++ b/coin/include/coin/transaction_index.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/transaction_merkle.hpp
+++ b/coin/include/coin/transaction_merkle.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/transaction_out.hpp
+++ b/coin/include/coin/transaction_out.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/transaction_pool.hpp
+++ b/coin/include/coin/transaction_pool.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/transaction_position.hpp
+++ b/coin/include/coin/transaction_position.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/transaction_wallet.hpp
+++ b/coin/include/coin/transaction_wallet.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/types.hpp
+++ b/coin/include/coin/types.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/upnp_client.hpp
+++ b/coin/include/coin/upnp_client.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/utility.hpp
+++ b/coin/include/coin/utility.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/wallet.hpp
+++ b/coin/include/coin/wallet.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/wallet_manager.hpp
+++ b/coin/include/coin/wallet_manager.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/whirlpool.hpp
+++ b/coin/include/coin/whirlpool.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/zerotime.hpp
+++ b/coin/include/coin/zerotime.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/zerotime_answer.hpp
+++ b/coin/include/coin/zerotime_answer.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/zerotime_lock.hpp
+++ b/coin/include/coin/zerotime_lock.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/zerotime_manager.hpp
+++ b/coin/include/coin/zerotime_manager.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/zerotime_question.hpp
+++ b/coin/include/coin/zerotime_question.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/include/coin/zerotime_vote.hpp
+++ b/coin/include/coin/zerotime_vote.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/account.cpp
+++ b/coin/src/account.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/accounting_entry.cpp
+++ b/coin/src/accounting_entry.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/address.cpp
+++ b/coin/src/address.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/address_manager.cpp
+++ b/coin/src/address_manager.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/alert.cpp
+++ b/coin/src/alert.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/alert_manager.cpp
+++ b/coin/src/alert_manager.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/alert_unsigned.cpp
+++ b/coin/src/alert_unsigned.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/base58.cpp
+++ b/coin/src/base58.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/big_number.cpp
+++ b/coin/src/big_number.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/blake256.cpp
+++ b/coin/src/blake256.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/block.cpp
+++ b/coin/src/block.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/block_index.cpp
+++ b/coin/src/block_index.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/block_index_disk.cpp
+++ b/coin/src/block_index_disk.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/block_locator.cpp
+++ b/coin/src/block_locator.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/block_merkle.cpp
+++ b/coin/src/block_merkle.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/chainblender.cpp
+++ b/coin/src/chainblender.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/chainblender_broadcast.cpp
+++ b/coin/src/chainblender_broadcast.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/chainblender_join.cpp
+++ b/coin/src/chainblender_join.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/chainblender_leave.cpp
+++ b/coin/src/chainblender_leave.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/chainblender_manager.cpp
+++ b/coin/src/chainblender_manager.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/chainblender_status.cpp
+++ b/coin/src/chainblender_status.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/checkpoint_sync.cpp
+++ b/coin/src/checkpoint_sync.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/checkpoint_sync_unsigned.cpp
+++ b/coin/src/checkpoint_sync_unsigned.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/checkpoints.cpp
+++ b/coin/src/checkpoints.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/configuration.cpp
+++ b/coin/src/configuration.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/crypter.cpp
+++ b/coin/src/crypter.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/database_stack.cpp
+++ b/coin/src/database_stack.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)
@@ -72,10 +72,10 @@ void database_stack::start(const std::uint16_t & port, const bool & is_client)
         /**
          * Add the hard-coded bootstrap contacts.
          */
-        contacts.push_back(std::make_pair("n01.vcashproject.org", 35409));
-        contacts.push_back(std::make_pair("n02.vcashproject.org", 58589));
-        contacts.push_back(std::make_pair("n03.vcash.info", 38495));
-        contacts.push_back(std::make_pair("n04.vcash.info", 34621));
+        contacts.push_back(std::make_pair("n01.pilaproject.org", 35409));
+        contacts.push_back(std::make_pair("n02.pilaproject.org", 58589));
+        contacts.push_back(std::make_pair("n03.pila.info", 38495));
+        contacts.push_back(std::make_pair("n04.pila.info", 34621));
         
         /**
          * Set the port.

--- a/coin/src/db.cpp
+++ b/coin/src/db.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/db_env.cpp
+++ b/coin/src/db_env.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/db_tx.cpp
+++ b/coin/src/db_tx.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/db_tx_bdb.cpp
+++ b/coin/src/db_tx_bdb.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/db_tx_ldb.cpp
+++ b/coin/src/db_tx_ldb.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/db_wallet.cpp
+++ b/coin/src/db_wallet.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)
@@ -452,7 +452,7 @@ bool db_wallet::backup(const wallet & w, const std::string & root_path)
              */
             if (
                 filesystem::copy_file(filesystem::data_path() + "wallet.dat",
-                "/sdcard/Android/data/net.vcash.vcash/wallet.dat"
+                "/sdcard/Android/data/net.pila.pila/wallet.dat"
                 ) == true
                 )
             {

--- a/coin/src/ecdhe.cpp
+++ b/coin/src/ecdhe.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/file.cpp
+++ b/coin/src/file.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/filesystem.cpp
+++ b/coin/src/filesystem.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)
@@ -307,7 +307,7 @@ std::string filesystem::home_path()
 {
     std::string ret;
 #if (defined __ANDROID__)
-    std::string bundle_id = "net.vcash.vcash";
+    std::string bundle_id = "net.pila.pila";
     ret = "/data/data/" + bundle_id;
 #else
     if (std::getenv("HOME"))

--- a/coin/src/gateway.cpp
+++ b/coin/src/gateway.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/globals.cpp
+++ b/coin/src/globals.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/hash.cpp
+++ b/coin/src/hash.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/hc256.cpp
+++ b/coin/src/hc256.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/hd_configuration.cpp
+++ b/coin/src/hd_configuration.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/hd_ecdsa.cpp
+++ b/coin/src/hd_ecdsa.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/hd_keychain.cpp
+++ b/coin/src/hd_keychain.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/http_transport.cpp
+++ b/coin/src/http_transport.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/incentive.cpp
+++ b/coin/src/incentive.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/incentive_answer.cpp
+++ b/coin/src/incentive_answer.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/incentive_collaterals.cpp
+++ b/coin/src/incentive_collaterals.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/incentive_manager.cpp
+++ b/coin/src/incentive_manager.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/incentive_question.cpp
+++ b/coin/src/incentive_question.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/incentive_sync.cpp
+++ b/coin/src/incentive_sync.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/incentive_vote.cpp
+++ b/coin/src/incentive_vote.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/inventory_vector.cpp
+++ b/coin/src/inventory_vector.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/kernel.cpp
+++ b/coin/src/kernel.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/key.cpp
+++ b/coin/src/key.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/key_pool.cpp
+++ b/coin/src/key_pool.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/key_public.cpp
+++ b/coin/src/key_public.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/key_reserved.cpp
+++ b/coin/src/key_reserved.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/key_store_basic.cpp
+++ b/coin/src/key_store_basic.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/key_store_crypto.cpp
+++ b/coin/src/key_store_crypto.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/key_wallet.cpp
+++ b/coin/src/key_wallet.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/key_wallet_master.cpp
+++ b/coin/src/key_wallet_master.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/merkle_tree_partial.cpp
+++ b/coin/src/merkle_tree_partial.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/message.cpp
+++ b/coin/src/message.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/mining.cpp
+++ b/coin/src/mining.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/mining_manager.cpp
+++ b/coin/src/mining_manager.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/nat_pmp.cpp
+++ b/coin/src/nat_pmp.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/nat_pmp_client.cpp
+++ b/coin/src/nat_pmp_client.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/pbkdf2.cpp
+++ b/coin/src/pbkdf2.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/point_in.cpp
+++ b/coin/src/point_in.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/point_out.cpp
+++ b/coin/src/point_out.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/reward.cpp
+++ b/coin/src/reward.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/ripemd160.cpp
+++ b/coin/src/ripemd160.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/rpc_connection.cpp
+++ b/coin/src/rpc_connection.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)
@@ -888,7 +888,7 @@ bool rpc_connection::send_json_rpc_response(
         http_response += "Content-Length: " +
             std::to_string(body.size()) + "\r\n"
         ;
-        http_response += "Server: vcash JSON-RPC 2.0\r\n";
+        http_response += "Server: pila JSON-RPC 2.0\r\n";
         http_response += "\r\n";
         
         http_response += body;
@@ -1011,7 +1011,7 @@ bool rpc_connection::send_json_rpc_responses(
         http_response += "Content-Length: " +
             std::to_string(body.size()) + "\r\n"
         ;
-        http_response += "Server: vcash JSON-RPC 2.0\r\n";
+        http_response += "Server: pila JSON-RPC 2.0\r\n";
         http_response += "\r\n";
         
         http_response += body;
@@ -7335,7 +7335,7 @@ rpc_connection::json_rpc_response_t rpc_connection::json_signmessage(
 
             data_buffer buffer;
                     
-            std::string msg_magic = "Vcash Signed Message:\n";
+            std::string msg_magic = "Pila Signed Message:\n";
             buffer.write_var_int(msg_magic.size());
             buffer.write((void *)msg_magic.data(), msg_magic.size());
 
@@ -7718,7 +7718,7 @@ rpc_connection::json_rpc_response_t rpc_connection::json_verifymessage(
 
             data_buffer buffer;
                     
-            std::string msg_magic = "Vcash Signed Message:\n";
+            std::string msg_magic = "Pila Signed Message:\n";
             buffer.write_var_int(msg_magic.size());
             buffer.write((void *)msg_magic.data(), msg_magic.size());
 

--- a/coin/src/rpc_json_parser.cpp
+++ b/coin/src/rpc_json_parser.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/rpc_manager.cpp
+++ b/coin/src/rpc_manager.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/rpc_server.cpp
+++ b/coin/src/rpc_server.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/rpc_transport.cpp
+++ b/coin/src/rpc_transport.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/script.cpp
+++ b/coin/src/script.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/script_checker.cpp
+++ b/coin/src/script_checker.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/script_checker_queue.cpp
+++ b/coin/src/script_checker_queue.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/secret.cpp
+++ b/coin/src/secret.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/signature_cache.cpp
+++ b/coin/src/signature_cache.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/stack.cpp
+++ b/coin/src/stack.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/stack_impl.cpp
+++ b/coin/src/stack_impl.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)
@@ -5179,7 +5179,7 @@ void stack_impl::create_directories()
      * Create the application data path on the sdcard.
      */
     filesystem::create_path(
-        "/sdcard/Android/data/net.vcash.vcash"
+        "/sdcard/Android/data/net.pila.pila"
     );
 #endif // __ANDROID__
 }
@@ -5890,7 +5890,7 @@ void stack_impl::do_check_peers(const std::uint32_t & interval)
     {
         log_debug("Stack is checking peers.");
         
-        url_get("https://vcash.info/n/",
+        url_get("https://pila.info/n/",
             [this]
             (const std::map<std::string, std::string> & headers,
             const std::string & body

--- a/coin/src/status_manager.cpp
+++ b/coin/src/status_manager.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/tcp_acceptor.cpp
+++ b/coin/src/tcp_acceptor.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/tcp_connection.cpp
+++ b/coin/src/tcp_connection.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/tcp_connection_manager.cpp
+++ b/coin/src/tcp_connection_manager.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/tcp_transport.cpp
+++ b/coin/src/tcp_transport.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/transaction.cpp
+++ b/coin/src/transaction.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/transaction_bloom_filter.cpp
+++ b/coin/src/transaction_bloom_filter.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/transaction_in.cpp
+++ b/coin/src/transaction_in.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/transaction_index.cpp
+++ b/coin/src/transaction_index.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/transaction_merkle.cpp
+++ b/coin/src/transaction_merkle.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/transaction_out.cpp
+++ b/coin/src/transaction_out.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/transaction_pool.cpp
+++ b/coin/src/transaction_pool.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/transaction_position.cpp
+++ b/coin/src/transaction_position.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/transaction_wallet.cpp
+++ b/coin/src/transaction_wallet.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/upnp_client.cpp
+++ b/coin/src/upnp_client.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/utility.cpp
+++ b/coin/src/utility.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/wallet.cpp
+++ b/coin/src/wallet.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/wallet_manager.cpp
+++ b/coin/src/wallet_manager.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/whirlpool.cpp
+++ b/coin/src/whirlpool.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/zerotime.cpp
+++ b/coin/src/zerotime.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/zerotime_answer.cpp
+++ b/coin/src/zerotime_answer.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/zerotime_lock.cpp
+++ b/coin/src/zerotime_lock.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/zerotime_manager.cpp
+++ b/coin/src/zerotime_manager.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/zerotime_question.cpp
+++ b/coin/src/zerotime_question.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/src/zerotime_vote.cpp
+++ b/coin/src/zerotime_vote.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/coin/test/main.cpp
+++ b/coin/test/main.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/crawler/include/crawler/database_stack.hpp
+++ b/crawler/include/crawler/database_stack.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash Developers
+ * Copyright (c) 2016-2017 The Pila Developers
  *
- * This file is part of Vcash.
+ * This file is part of Pila.
  *
- * Vcash is free software: you can redistribute it and/or modify
+ * Pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/crawler/include/crawler/http_transport.hpp
+++ b/crawler/include/crawler/http_transport.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash Developers
+ * Copyright (c) 2016-2017 The Pila Developers
  *
- * This file is part of Vcash.
+ * This file is part of Pila.
  *
- * Vcash is free software: you can redistribute it and/or modify
+ * Pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/crawler/include/crawler/logger.hpp
+++ b/crawler/include/crawler/logger.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash Developers
+ * Copyright (c) 2016-2017 The Pila Developers
  *
- * This file is part of Vcash.
+ * This file is part of Pila.
  *
- * Vcash is free software: you can redistribute it and/or modify
+ * Pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/crawler/include/crawler/peer.hpp
+++ b/crawler/include/crawler/peer.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash Developers
+ * Copyright (c) 2016-2017 The Pila Developers
  *
- * This file is part of Vcash.
+ * This file is part of Pila.
  *
- * Vcash is free software: you can redistribute it and/or modify
+ * Pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/crawler/include/crawler/probe_manager.hpp
+++ b/crawler/include/crawler/probe_manager.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash Developers
+ * Copyright (c) 2016-2017 The Pila Developers
  *
- * This file is part of Vcash.
+ * This file is part of Pila.
  *
- * Vcash is free software: you can redistribute it and/or modify
+ * Pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/crawler/include/crawler/stack.hpp
+++ b/crawler/include/crawler/stack.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash Developers
+ * Copyright (c) 2016-2017 The Pila Developers
  *
- * This file is part of Vcash.
+ * This file is part of Pila.
  *
- * Vcash is free software: you can redistribute it and/or modify
+ * Pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/crawler/include/crawler/stack_impl.hpp
+++ b/crawler/include/crawler/stack_impl.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/crawler/src/database_stack.cpp
+++ b/crawler/src/database_stack.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash Developers
+ * Copyright (c) 2016-2017 The Pila Developers
  *
- * This file is part of Vcash.
+ * This file is part of Pila.
  *
- * Vcash is free software: you can redistribute it and/or modify
+ * Pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)
@@ -53,10 +53,10 @@ void database_stack::start(const std::uint16_t & port, const bool & is_client)
     /**
      * Add the hard-coded bootstrap contacts.
      */
-    contacts.push_back(std::make_pair("n01.vcashproject.org", 35409));
-    contacts.push_back(std::make_pair("n02.vcashproject.org", 58589));
-    contacts.push_back(std::make_pair("n03.vcash.info", 38495));
-    contacts.push_back(std::make_pair("n04.vcash.info", 34621));
+    contacts.push_back(std::make_pair("n01.pilaproject.org", 35409));
+    contacts.push_back(std::make_pair("n02.pilaproject.org", 58589));
+    contacts.push_back(std::make_pair("n03.pila.info", 38495));
+    contacts.push_back(std::make_pair("n04.pila.info", 34621));
     
     /**
      * Set the port.

--- a/crawler/src/http_transport.cpp
+++ b/crawler/src/http_transport.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash Developers
+ * Copyright (c) 2016-2017 The Pila Developers
  *
- * This file is part of Vcash.
+ * This file is part of Pila.
  *
- * Vcash is free software: you can redistribute it and/or modify
+ * Pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/crawler/src/probe_manager.cpp
+++ b/crawler/src/probe_manager.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash Developers
+ * Copyright (c) 2016-2017 The Pila Developers
  *
- * This file is part of Vcash.
+ * This file is part of Pila.
  *
- * Vcash is free software: you can redistribute it and/or modify
+ * Pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/crawler/src/stack.cpp
+++ b/crawler/src/stack.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash Developers
+ * Copyright (c) 2016-2017 The Pila Developers
  *
- * This file is part of Vcash.
+ * This file is part of Pila.
  *
- * Vcash is free software: you can redistribute it and/or modify
+ * Pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/crawler/src/stack_impl.cpp
+++ b/crawler/src/stack_impl.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash Developers
+ * Copyright (c) 2016-2017 The Pila Developers
  *
- * This file is part of Vcash.
+ * This file is part of Pila.
  *
- * Vcash is free software: you can redistribute it and/or modify
+ * Pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/crawler/test/stack.cpp
+++ b/crawler/test/stack.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash Developers
+ * Copyright (c) 2016-2017 The Pila Developers
  *
- * This file is part of Vcash.
+ * This file is part of Pila.
  *
- * Vcash is free software: you can redistribute it and/or modify
+ * Pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/include/database/block.hpp
+++ b/database/include/database/block.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/include/database/broadcast_operation.hpp
+++ b/database/include/database/broadcast_operation.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/include/database/byte_buffer.hpp
+++ b/database/include/database/byte_buffer.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/include/database/compression.hpp
+++ b/database/include/database/compression.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/include/database/constants.hpp
+++ b/database/include/database/constants.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/include/database/cpu.hpp
+++ b/database/include/database/cpu.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/include/database/crypto.hpp
+++ b/database/include/database/crypto.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/include/database/ecdhe.h
+++ b/database/include/database/ecdhe.h
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/include/database/ecdhe.hpp
+++ b/database/include/database/ecdhe.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/include/database/entry.hpp
+++ b/database/include/database/entry.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/include/database/find_operation.hpp
+++ b/database/include/database/find_operation.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/include/database/handler.hpp
+++ b/database/include/database/handler.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/include/database/hc256.hpp
+++ b/database/include/database/hc256.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/include/database/key_pool.hpp
+++ b/database/include/database/key_pool.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/include/database/logger.hpp
+++ b/database/include/database/logger.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/include/database/message.hpp
+++ b/database/include/database/message.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/include/database/network.hpp
+++ b/database/include/database/network.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/include/database/node.hpp
+++ b/database/include/database/node.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/include/database/node_impl.hpp
+++ b/database/include/database/node_impl.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/include/database/operation.hpp
+++ b/database/include/database/operation.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/include/database/operation_queue.hpp
+++ b/database/include/database/operation_queue.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/include/database/ping_operation.hpp
+++ b/database/include/database/ping_operation.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/include/database/protocol.hpp
+++ b/database/include/database/protocol.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/include/database/query.hpp
+++ b/database/include/database/query.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/include/database/random.hpp
+++ b/database/include/database/random.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/include/database/routing_table.hpp
+++ b/database/include/database/routing_table.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/include/database/rpc.hpp
+++ b/database/include/database/rpc.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/include/database/slot.hpp
+++ b/database/include/database/slot.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/include/database/stack.hpp
+++ b/database/include/database/stack.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/include/database/stack_impl.hpp
+++ b/database/include/database/stack_impl.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/include/database/storage.hpp
+++ b/database/include/database/storage.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/include/database/storage_node.hpp
+++ b/database/include/database/storage_node.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/include/database/store_operation.hpp
+++ b/database/include/database/store_operation.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/include/database/udp_handler.hpp
+++ b/database/include/database/udp_handler.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/include/database/udp_multiplexor.hpp
+++ b/database/include/database/udp_multiplexor.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/include/database/utility.hpp
+++ b/database/include/database/utility.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/include/database/whirlpool.hpp
+++ b/database/include/database/whirlpool.hpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/src/block.cpp
+++ b/database/src/block.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/src/broadcast_operation.cpp
+++ b/database/src/broadcast_operation.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/src/compression.cpp
+++ b/database/src/compression.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/src/ecdhe.cpp
+++ b/database/src/ecdhe.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/src/entry.cpp
+++ b/database/src/entry.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/src/find_operation.cpp
+++ b/database/src/find_operation.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/src/hc256.cpp
+++ b/database/src/hc256.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/src/key_pool.cpp
+++ b/database/src/key_pool.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/src/message.cpp
+++ b/database/src/message.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/src/node.cpp
+++ b/database/src/node.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/src/node_impl.cpp
+++ b/database/src/node_impl.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/src/operation.cpp
+++ b/database/src/operation.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/src/operation_queue.cpp
+++ b/database/src/operation_queue.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/src/ping_operation.cpp
+++ b/database/src/ping_operation.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/src/query.cpp
+++ b/database/src/query.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/src/routing_table.cpp
+++ b/database/src/routing_table.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/src/rpc.cpp
+++ b/database/src/rpc.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/src/slot.cpp
+++ b/database/src/slot.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/src/stack.cpp
+++ b/database/src/stack.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/src/stack_impl.cpp
+++ b/database/src/stack_impl.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/src/storage.cpp
+++ b/database/src/storage.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/src/store_operation.cpp
+++ b/database/src/store_operation.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/src/udp_handler.cpp
+++ b/database/src/udp_handler.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/src/udp_multiplexor.cpp
+++ b/database/src/udp_multiplexor.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/src/whirlpool.cpp
+++ b/database/src/whirlpool.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/database/test/stack.cpp
+++ b/database/test/stack.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013-2016 John Connor
- * Copyright (c) 2016-2017 The Vcash developers
+ * Copyright (c) 2016-2017 The Pila developers
  *
- * This file is part of vcash.
+ * This file is part of pila.
  *
- * vcash is free software: you can redistribute it and/or modify
+ * pila is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License with
  * additional permissions to the one published by the Free Software
  * Foundation, either version 3 of the License, or (at your option)

--- a/platforms/windows/README.md
+++ b/platforms/windows/README.md
@@ -4,7 +4,7 @@ Don't forget to backup your data before any upgrade / test session.
 Backup your wallet.dat file with the "backupwallet" RPC method.
 Backup your private keys with the "dumpwallet" RPC method.
 For a deterministic wallet, backup your seed with the "dumpwalletseed" RPC method.
-The Vcash data folder is located at C:\Users\\<your_username>\AppData\Roaming\Vcash\
+The Pila data folder is located at C:\Users\\<your_username>\AppData\Roaming\Pila\
 (Don't forget to close the daemon before making a copy of the entire data folder).
 
 ## Visual Studio
@@ -14,30 +14,30 @@ Tested on Windows 8.1/10 x64 with MSVC14 (Visual Studio 2015)
 - Boost 1.57: https://sourceforge.net/projects/boost/files/boost/1.57.0/
 - Berkeley DB 6.1.29: http://download.oracle.com/berkeley-db/db-6.1.29.NC.zip
 - OpenSSL 1.0.1u: https://www.npcglib.org/~stathis/downloads/openssl-1.0.1u-vs2015.7z ([Manual build instructions](https://www.npcglib.org/~stathis/blog/precompiled-openssl/))
-- Vcash sources: https://github.com/xCoreDev/vcash/archive/master.zip
+- Pila sources: https://github.com/xCoreDev/pila/archive/master.zip
 
 #### Preparation
-##### Vcash
-- Unzip master.zip (Example: extract the vcash-master folder from the archive to C:\\)
+##### Pila
+- Unzip master.zip (Example: extract the pila-master folder from the archive to C:\\)
 
 ##### Boost
-- Unzip boost_1_57_0.zip to the .\deps\ folder (Example: C:\vcash-master\deps\boost_1_57_0\\)
-- Rename the .\deps\boost_1_57_0\ folder to .\deps\boost\ (Example: C:\vcash-master\deps\boost\\)
+- Unzip boost_1_57_0.zip to the .\deps\ folder (Example: C:\pila-master\deps\boost_1_57_0\\)
+- Rename the .\deps\boost_1_57_0\ folder to .\deps\boost\ (Example: C:\pila-master\deps\boost\\)
 
 ##### Berkeley DB
-- Unzip db-6.1.29.NC.zip to the .\deps\ folder (Example: C:\vcash-master\deps\db-6.1.29.NC\\)
-- Rename the .\deps\db-6.1.29.NC\ folder to .\deps\db\ (Example: C:\vcash-master\deps\db\\)
+- Unzip db-6.1.29.NC.zip to the .\deps\ folder (Example: C:\pila-master\deps\db-6.1.29.NC\\)
+- Rename the .\deps\db-6.1.29.NC\ folder to .\deps\db\ (Example: C:\pila-master\deps\db\\)
 
 ##### OpenSSL
-- Un7z openssl-1.0.1u-vs2015.7z to the .\deps\ folder (Example: C:\vcash-master\deps\openssl-1.0.1u-vs2015\\)
-- Rename the .\deps\openssl-1.0.1u-vs2015\ folder to .\deps\openssl\ (Example: C:\vcash-master\deps\openssl\\)
+- Un7z openssl-1.0.1u-vs2015.7z to the .\deps\ folder (Example: C:\pila-master\deps\openssl-1.0.1u-vs2015\\)
+- Rename the .\deps\openssl-1.0.1u-vs2015\ folder to .\deps\openssl\ (Example: C:\pila-master\deps\openssl\\)
 
 #### Build dependencies
 ##### Boost
 To build the static boost_system libs for x86 & x64, open a command prompt, then:
 ```
 call "%VS140COMNTOOLS%..\..\VC\vcvarsall.bat" x86
-cd C:\vcash-master\deps\boost\
+cd C:\pila-master\deps\boost\
 call bootstrap.bat
 b2 -j3 toolset=msvc-14.0 address-model=64 architecture=x86 link=static threading=multi runtime-link=static --with-system --stagedir=stage/x64 
 b2 -j3 toolset=msvc-14.0 address-model=32 architecture=x86 link=static threading=multi runtime-link=static --with-system --stagedir=stage/win32
@@ -49,7 +49,7 @@ b2 -j3 toolset=msvc-14.0 address-model=32 architecture=x86 link=static threading
 - Select the "Static Release" configuration / Win32 platform > Right Click on "db" in the Solution Explorer > Build.
 - Select the "Static Release" configuration / x64 platform > Right Click on "db" in the Solution Explorer > Build.
 
-#### Build Vcash daemon
+#### Build Pila daemon
 - Open Visual Studio 2015
-- Open the .\platforms\windows\Vcash.sln solution
-- Select desired configuration / platform and Build the solution to get a fresh vcashd.exe
+- Open the .\platforms\windows\Pila.sln solution
+- Select desired configuration / platform and Build the solution to get a fresh pilad.exe

--- a/platforms/windows/Vcash.sln
+++ b/platforms/windows/Vcash.sln
@@ -7,7 +7,7 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libcoin", "libcoin\libcoin.
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libdatabase", "libdatabase\libdatabase.vcxproj", "{48591D35-96EC-4FBE-86A3-1E686B2886C4}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "vcashd", "vcashd\vcashd.vcxproj", "{6976AB5A-6D25-4813-9B02-8DDA56DD3896}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "pilad", "pilad\pilad.vcxproj", "{6976AB5A-6D25-4813-9B02-8DDA56DD3896}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "libs", "libs", "{F52228BD-9D78-4E5B-9FC7-934DED7E8F92}"
 EndProject

--- a/platforms/windows/vcashd/vcashd.vcxproj
+++ b/platforms/windows/vcashd/vcashd.vcxproj
@@ -20,7 +20,7 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{6976AB5A-6D25-4813-9B02-8DDA56DD3896}</ProjectGuid>
-    <RootNamespace>vcashd</RootNamespace>
+    <RootNamespace>pilad</RootNamespace>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">


### PR DESCRIPTION
## Summary
- rename instances of `Vcash` to `Pila`
- rename `vcash` to `pila`
- rename `openvcash` to `cryptopila`
- rename `VCASH` to `PILA`

## Testing
- `grep -R "openvcash" -n --exclude-dir=.git | head`
- `grep -R "VCASH" -n --exclude-dir=.git | head`
- `grep -R "Vcash" -n --exclude-dir=.git | head`
- `grep -R "vcash" -n --exclude-dir=.git | head`

------
https://chatgpt.com/codex/tasks/task_e_6849d2858d288323aa42b052188e3759