### PR TITLE
Start Go migration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,4 @@ Dependencies:
 * OpenSSL == 1.0.2k
 
 Linux: use https://github.com/cryptopila/pila-scripts
+For the ongoing migration to Go, see [docs/migration_plan.md](docs/migration_plan.md).

--- a/docs/migration_plan.md
+++ b/docs/migration_plan.md
@@ -1,0 +1,36 @@
+# Migration to Go - Initial Plan
+
+This document outlines the initial ideas for migrating the current C++ codebase to Go.
+
+## Overview of the Current Project
+- Rewrite/enhancement based on Peercoin PoS and Bitcoin PoW
+- Contains custom features: UDP layer, ZeroTime transaction locking, Incentive Reward, ChainBlender
+- Relies heavily on Boost, Berkeley DB and OpenSSL
+- Codebase has roughly 100k lines of C/C++ spread across `coin`, `database` and `crawler`
+
+## Probability Estimate
+Due to the large size and complexity of the existing code, the migration to Go is estimated to have a **low probability of success (around 20%)** without significant resources and a dedicated team.
+
+## Suggested Approach
+1. **Evaluation**: map all current modules and dependencies.
+2. **Architecture Definition**: choose Go packages to replace C++ components:
+   - `golang.org/x/crypto` for cryptography
+   - `goleveldb` for storage
+   - a P2P network layer inspired by `btcd`
+3. **Modeling**: design Go structures for blocks, transactions, wallets and networking.
+4. **Networking**: implement P2P communication using Go libraries, replacing Boost Asio code.
+5. **Consensus**: reimplement PoW/PoS and reward logic in Go.
+6. **Custom Features**: port ZeroTime, ChainBlender and Incentive.
+7. **RPC Services**: expose wallet and blockchain operations via Go's HTTP or gRPC.
+8. **Build & Tests**: use `go mod`, write unit and integration tests for each module.
+
+## What Can Be Ignored or Replaced
+- Custom cryptographic utility implementations can be replaced by Go's `crypto` packages.
+- LevelDB C++ code can be replaced by the Go wrapper `goleveldb`.
+- The O(1) propagation layer and crawler can be substituted with existing P2P frameworks used by `btcd`.
+- C++ build scripts for Windows/Unix and JNI bindings can be dropped in favour of Go's cross-platform build tools.
+
+## Next Steps
+- Prepare a minimal Go module with the chosen dependencies (`golang.org/x/crypto`, `goleveldb`).
+- Start with a small prototype implementing basic block and transaction structures.
+


### PR DESCRIPTION
## Summary
- add initial doc with Go migration plan
- reference doc in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849c8eebc148323bc825eb61ce1a873