### PR TITLE
Add module mapping for Go migration

### DIFF
--- a/docs/migration_plan.md
+++ b/docs/migration_plan.md
@@ -6,7 +6,8 @@ This document outlines the initial ideas for migrating the current C++ codebase 
 - Rewrite/enhancement based on Peercoin PoS and Bitcoin PoW
 - Contains custom features: UDP layer, ZeroTime transaction locking, Incentive Reward, ChainBlender
 - Relies heavily on Boost, Berkeley DB and OpenSSL
-- Codebase has roughly 100k lines of C/C++ spread across `coin`, `database` and `crawler`
+- Codebase has roughly 100k lines of C/C++ spread across `coin`, `database` and `crawler`.
+  See [module_mapping.md](module_mapping.md) for a proposed mapping of these directories to Go packages.
 
 ## Probability Estimate
 Due to the large size and complexity of the existing code, the migration to Go is estimated to have a **low probability of success (around 20%)** without significant resources and a dedicated team.

--- a/docs/module_mapping.md
+++ b/docs/module_mapping.md
@@ -1,0 +1,11 @@
+# C++ to Go Module Mapping
+
+This table lists the main C++ directories in the current project and suggests an equivalent Go module or third-party package that could be used during the migration.
+
+| C++ Directory | Purpose | Suggested Go Replacement |
+|---------------|---------|--------------------------|
+| `coin` | Core blockchain logic, wallet functionality, networking and custom features such as ZeroTime, Incentive Reward and ChainBlender. | Use the `btcsuite/btcd` packages for Bitcoin-style networking and blockchain structures along with `golang.org/x/crypto` for cryptography. |
+| `database` | Provides the O(1) block and transaction propagation layer, wrapping LevelDB and related database utilities. | The `goleveldb/leveldb` library can provide similar storage capabilities. |
+| `crawler` | Discovers peers and monitors node availability using Boost.Asio networking. | Replace with Go's networking primitives or a P2P framework such as `libp2p` or the `btcd` peer package. |
+
+These mappings are preliminary suggestions and may be adjusted as the migration progresses.


### PR DESCRIPTION
## Summary
- document the purpose of `coin`, `database` and `crawler`
- link each directory to an equivalent Go package
- reference the new mapping from the migration plan

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6849eaa66f6083238b14a26d3698a5a7