### PR TITLE
Add Go module stub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ crawler/bin/
 crawler/test/bin/
 database/bin/
 database/test/bin/
+/pila

--- a/cmd/pila/main.go
+++ b/cmd/pila/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("pila go stub running")
+}

--- a/docs/migration_plan.md
+++ b/docs/migration_plan.md
@@ -43,3 +43,15 @@ Due to the large size and complexity of the existing code, the migration to Go i
 - Prepare a minimal Go module with the chosen dependencies (`golang.org/x/crypto`, `goleveldb`).
 - Start with a small prototype implementing basic block and transaction structures.
 
+## Verifying the Go Environment
+
+After running `go mod init pila`, a tiny executable can be built to
+confirm that Go is installed correctly. From the repository root run:
+
+```bash
+go run ./cmd/pila
+```
+
+This should print `pila go stub running` confirming the environment is ready
+for further development.
+

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module pila
+
+go 1.23.8


### PR DESCRIPTION
## Summary
- setup Go module
- add `cmd/pila` stub
- ignore built binary
- document how to run the stub in migration docs

## Testing
- `go run ./cmd/pila`

------
https://chatgpt.com/codex/tasks/task_e_6849eb6baef483238816584d824f157c