### PR TITLE
Implement improved handshake functions

### DIFF
--- a/docs/migration_plan.md
+++ b/docs/migration_plan.md
@@ -29,7 +29,7 @@ Due to the large size and complexity of the existing code, the migration to Go i
 
 - [ ] Evaluate dependencies in `coin`, `database` and `crawler`.
 - [x] Prototype block and transaction structures in Go (complete).
-- [ ] Implement a basic P2P handshake.
+- [x] Implement a basic P2P handshake.
 - [ ] Stub LevelDB interactions for the `database` package.
 - [ ] Replace Boost-based networking in the `crawler` component.
 

--- a/go/pkg/coin/constants.go
+++ b/go/pkg/coin/constants.go
@@ -40,4 +40,8 @@ const (
 	WorkAndStakeTargetSpacing = 200
 
 	PowCutoffBlock = 2147483647 - 1
+
+	// P2PProtocolVersion is used during peer handshakes to ensure
+	// both sides speak the same protocol.
+	P2PProtocolVersion uint32 = 1
 )

--- a/go/pkg/coin/handshake.go
+++ b/go/pkg/coin/handshake.go
@@ -1,0 +1,61 @@
+package coin
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"time"
+)
+
+// handshakeMessage is exchanged by peers when establishing a connection.
+type handshakeMessage struct {
+	Protocol uint32 `json:"protocol"`
+	NodeID   string `json:"node"`
+}
+
+// PerformHandshake initiates a handshake with the remote peer. It sends a
+// handshakeMessage containing the local node ID and waits for the remote
+// response. A protocol mismatch results in an error.
+// PerformHandshake initiates a handshake with the remote peer and returns the
+// remote node ID if successful.
+func PerformHandshake(conn net.Conn, nodeID string) (string, error) {
+	enc := json.NewEncoder(conn)
+	dec := json.NewDecoder(conn)
+
+	hello := handshakeMessage{Protocol: P2PProtocolVersion, NodeID: nodeID}
+	if err := enc.Encode(&hello); err != nil {
+		return "", err
+	}
+
+	// Set a small deadline so tests won't hang forever.
+	_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	var resp handshakeMessage
+	if err := dec.Decode(&resp); err != nil {
+		return "", err
+	}
+	// Reset the deadline so future reads are not affected.
+	_ = conn.SetReadDeadline(time.Time{})
+
+	if resp.Protocol != hello.Protocol {
+		return "", fmt.Errorf("unexpected protocol %d", resp.Protocol)
+	}
+	return resp.NodeID, nil
+}
+
+// HandleHandshake responds to a handshake request from a peer and returns the
+// remote node ID.
+func HandleHandshake(conn net.Conn, nodeID string) (string, error) {
+	dec := json.NewDecoder(conn)
+	enc := json.NewEncoder(conn)
+
+	var req handshakeMessage
+	if err := dec.Decode(&req); err != nil {
+		return "", err
+	}
+
+	resp := handshakeMessage{Protocol: P2PProtocolVersion, NodeID: nodeID}
+	if err := enc.Encode(&resp); err != nil {
+		return "", err
+	}
+	return req.NodeID, nil
+}

--- a/go/pkg/coin/handshake_test.go
+++ b/go/pkg/coin/handshake_test.go
@@ -1,0 +1,67 @@
+package coin
+
+import (
+	"encoding/json"
+	"net"
+	"sync"
+	"testing"
+)
+
+func TestHandshake(t *testing.T) {
+	a, b := net.Pipe()
+	defer a.Close()
+	defer b.Close()
+
+	var srvID string
+	var srvErr error
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		srvID, srvErr = HandleHandshake(b, "server")
+	}()
+
+	cliID, err := PerformHandshake(a, "client")
+	if err != nil {
+		t.Fatalf("handshake failed: %v", err)
+	}
+	wg.Wait()
+	if srvErr != nil {
+		t.Fatalf("server handshake failed: %v", srvErr)
+	}
+	if cliID != "server" || srvID != "client" {
+		t.Fatalf("unexpected ids cli=%s srv=%s", cliID, srvID)
+	}
+}
+
+func TestHandshakeMismatch(t *testing.T) {
+	a, b := net.Pipe()
+	defer a.Close()
+	defer b.Close()
+
+	var wg sync.WaitGroup
+	var srvErr error
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		dec := json.NewDecoder(b)
+		enc := json.NewEncoder(b)
+
+		var req handshakeMessage
+		if err := dec.Decode(&req); err != nil {
+			srvErr = err
+			return
+		}
+		resp := handshakeMessage{Protocol: P2PProtocolVersion + 1, NodeID: "server"}
+		srvErr = enc.Encode(&resp)
+	}()
+
+	id, err := PerformHandshake(a, "client")
+	if err == nil {
+		t.Fatalf("expected error, got id=%s", id)
+	}
+	wg.Wait()
+	if srvErr != nil {
+		t.Fatalf("server error: %v", srvErr)
+	}
+}


### PR DESCRIPTION
## Summary
- return peer node IDs from `PerformHandshake` and `HandleHandshake`
- add protocol version constant and clear read deadlines
- add mismatch test verifying protocol version

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6852d343f7108323ba9bec997313092c