### PR TITLE
Improve block validation

### DIFF
--- a/docs/migration_plan.md
+++ b/docs/migration_plan.md
@@ -30,7 +30,7 @@ Due to the large size and complexity of the existing code, the migration to Go i
 - [ ] Evaluate dependencies in `coin`, `database` and `crawler`.
 - [x] Prototype block and transaction structures in Go (complete).
 - [x] Implement a basic P2P handshake.
-- [ ] Stub LevelDB interactions for the `database` package.
+- [x] Stub LevelDB interactions for the `database` package.
 - [ ] Replace Boost-based networking in the `crawler` component.
 
 ## What Can Be Ignored or Replaced
@@ -52,10 +52,13 @@ Due to the large size and complexity of the existing code, the migration to Go i
 - Implemented placeholder `Block` and `Transaction` types in `pkg/`.
 - `main.go` originally printed a simple message; it now demonstrates writing and
   reading a block using `goleveldb`.
+- Introduced a stub `database` package wrapping `goleveldb`.
+- Added a minimal `crawler` package implementing peer connection and handshake tests.
+- Implemented basic block validation checking the merkle root.
 
 ## Upcoming Work
 - Expand the P2P network layer using a `btcd`-style implementation.
-- Flesh out block validation logic and integrate storage with `goleveldb`.
+- Continue improving block validation logic and integrate storage with `goleveldb`.
 
 ## Verifying the Go Environment
 

--- a/go/cmd/pila/main.go
+++ b/go/cmd/pila/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"log"
 
@@ -9,11 +10,26 @@ import (
 )
 
 func main() {
-	db, err := database.Open("./db")
+	list := flag.Bool("list", false, "list blocks")
+	dbPath := flag.String("db", "./db", "database path")
+	flag.Parse()
+
+	db, err := database.Open(*dbPath)
 	if err != nil {
 		log.Fatal(err)
 	}
 	defer db.Close()
+
+	if *list {
+		blocks, err := db.ListBlocks()
+		if err != nil {
+			log.Fatal(err)
+		}
+		for _, b := range blocks {
+			fmt.Printf("block %s with %d txs\n", b.Header.Hash()[:8], len(b.Transactions))
+		}
+		return
+	}
 
 	tx := coin.Transaction{
 		Version: 1,

--- a/go/cmd/pila/main.go
+++ b/go/cmd/pila/main.go
@@ -1,17 +1,15 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 
-	"github.com/syndtr/goleveldb/leveldb"
-
 	"pila/pkg/coin"
+	"pila/pkg/database"
 )
 
 func main() {
-	db, err := leveldb.OpenFile("./db", nil)
+	db, err := database.Open("./db")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -42,21 +40,11 @@ func main() {
 	}
 	blk.Header.MerkleRoot = blk.BuildMerkleRoot()
 
-	data, err := json.Marshal(blk)
+	if err := db.PutBlock(blk); err != nil {
+		log.Fatal(err)
+	}
+	out, err := db.GetBlock(blk.Header.Hash())
 	if err != nil {
-		log.Fatal(err)
-	}
-	if err := db.Put([]byte("block:1"), data, nil); err != nil {
-		log.Fatal(err)
-	}
-
-	raw, err := db.Get([]byte("block:1"), nil)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	var out coin.Block
-	if err := json.Unmarshal(raw, &out); err != nil {
 		log.Fatal(err)
 	}
 

--- a/go/pkg/coin/block.go
+++ b/go/pkg/coin/block.go
@@ -3,6 +3,7 @@ package coin
 import (
 	"encoding/binary"
 	"encoding/hex"
+	"fmt"
 )
 
 // BlockHeader mirrors the basic Bitcoin block header structure.
@@ -74,4 +75,24 @@ func (b Block) BuildMerkleRoot() string {
 	}
 
 	return hex.EncodeToString(layer[0])
+}
+
+// Validate performs basic sanity checks on the block.
+// It currently verifies the merkle root matches the transactions.
+func (b Block) Validate() error {
+	if len(b.Transactions) == 0 {
+		return fmt.Errorf("no transactions")
+	}
+	if b.Header.MerkleRoot != b.BuildMerkleRoot() {
+		return fmt.Errorf("invalid merkle root")
+	}
+	seen := make(map[string]struct{})
+	for _, tx := range b.Transactions {
+		h := tx.Hash()
+		if _, ok := seen[h]; ok {
+			return fmt.Errorf("duplicate transaction %s", h)
+		}
+		seen[h] = struct{}{}
+	}
+	return nil
 }

--- a/go/pkg/coin/block_test.go
+++ b/go/pkg/coin/block_test.go
@@ -1,0 +1,33 @@
+package coin
+
+import "testing"
+
+func TestBlockValidate(t *testing.T) {
+	tx := Transaction{Version: 1}
+	blk := Block{Header: BlockHeader{Version: 1}, Transactions: []Transaction{tx}}
+	blk.Header.MerkleRoot = blk.BuildMerkleRoot()
+	if err := blk.Validate(); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+}
+
+func TestBlockValidateMerkleError(t *testing.T) {
+	tx := Transaction{Version: 1}
+	blk := Block{Header: BlockHeader{Version: 1}, Transactions: []Transaction{tx}}
+	blk.Header.MerkleRoot = "bad"
+	if err := blk.Validate(); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestBlockValidateDuplicateTx(t *testing.T) {
+	tx := Transaction{Version: 1}
+	blk := Block{
+		Header:       BlockHeader{Version: 1},
+		Transactions: []Transaction{tx, tx},
+	}
+	blk.Header.MerkleRoot = blk.BuildMerkleRoot()
+	if err := blk.Validate(); err == nil {
+		t.Fatalf("expected error")
+	}
+}

--- a/go/pkg/crawler/crawler.go
+++ b/go/pkg/crawler/crawler.go
@@ -1,0 +1,55 @@
+package crawler
+
+import (
+	"log"
+	"net"
+
+	"pila/pkg/coin"
+)
+
+// Peer represents a remote peer connection.
+type Peer struct {
+	Conn net.Conn
+	ID   string
+}
+
+// Connect dials the address and performs a handshake using nodeID.
+func Connect(addr, nodeID string) (*Peer, error) {
+	c, err := net.Dial("tcp", addr)
+	if err != nil {
+		return nil, err
+	}
+	id, err := coin.PerformHandshake(c, nodeID)
+	if err != nil {
+		c.Close()
+		return nil, err
+	}
+	return &Peer{Conn: c, ID: id}, nil
+}
+
+// ListenAndServe listens on addr and handles incoming handshake connections.
+// For each successful connection, the remote node ID is logged.
+func ListenAndServe(addr, nodeID string) (net.Listener, error) {
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, err
+	}
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(conn net.Conn) {
+				defer conn.Close()
+				id, err := coin.HandleHandshake(conn, nodeID)
+				if err != nil {
+					log.Printf("handshake error: %v", err)
+					return
+				}
+				log.Printf("connected peer %s", id)
+			}(c)
+		}
+	}()
+	return ln, nil
+}

--- a/go/pkg/crawler/crawler_test.go
+++ b/go/pkg/crawler/crawler_test.go
@@ -42,3 +42,29 @@ func TestListenAndServeHandshakeError(t *testing.T) {
 		t.Fatalf("expected error")
 	}
 }
+
+func TestCrawlerConnectAndClose(t *testing.T) {
+	ln, err := ListenAndServe("127.0.0.1:0", "server")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	c := New("client")
+	peer, err := c.Connect(ln.Addr().String())
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+
+	if len(c.peers) != 1 {
+		t.Fatalf("expected 1 peer, got %d", len(c.peers))
+	}
+	if peer.ID != "server" {
+		t.Fatalf("unexpected peer id %s", peer.ID)
+	}
+
+	c.Close()
+	if _, err := peer.Conn.Write([]byte{0}); err == nil {
+		t.Fatalf("connection should be closed")
+	}
+}

--- a/go/pkg/crawler/crawler_test.go
+++ b/go/pkg/crawler/crawler_test.go
@@ -1,0 +1,44 @@
+package crawler
+
+import (
+	"net"
+	"testing"
+)
+
+func TestConnect(t *testing.T) {
+	ln, err := ListenAndServe("127.0.0.1:0", "server")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	peer, err := Connect(ln.Addr().String(), "client")
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer peer.Conn.Close()
+
+	if peer.ID != "server" {
+		t.Fatalf("expected server id, got %s", peer.ID)
+	}
+}
+
+func TestListenAndServeHandshakeError(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	go func() {
+		c, _ := ln.Accept()
+		defer c.Close()
+		// send invalid handshake
+		c.Write([]byte("invalid"))
+	}()
+
+	_, err = Connect(ln.Addr().String(), "client")
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+}

--- a/go/pkg/database/database.go
+++ b/go/pkg/database/database.go
@@ -1,0 +1,64 @@
+package database
+
+import (
+	"encoding/json"
+
+	"github.com/syndtr/goleveldb/leveldb"
+
+	"pila/pkg/coin"
+)
+
+// DB wraps a LevelDB instance.
+type DB struct {
+	db *leveldb.DB
+}
+
+// Open opens a LevelDB database located at path.
+func Open(path string) (*DB, error) {
+	d, err := leveldb.OpenFile(path, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &DB{db: d}, nil
+}
+
+// Close closes the underlying database.
+func (d *DB) Close() error { return d.db.Close() }
+
+// Put stores an arbitrary value under the given key.
+func (d *DB) Put(key string, val []byte) error {
+	return d.db.Put([]byte(key), val, nil)
+}
+
+// Get retrieves the raw value for key.
+func (d *DB) Get(key string) ([]byte, error) {
+	return d.db.Get([]byte(key), nil)
+}
+
+// PutBlock serializes and stores the block using its hash as the key.
+func (d *DB) PutBlock(b coin.Block) error {
+	if err := b.Validate(); err != nil {
+		return err
+	}
+	data, err := json.Marshal(b)
+	if err != nil {
+		return err
+	}
+	return d.Put("block:"+b.Header.Hash(), data)
+}
+
+// GetBlock loads the block identified by hash.
+func (d *DB) GetBlock(hash string) (coin.Block, error) {
+	var out coin.Block
+	raw, err := d.Get("block:" + hash)
+	if err != nil {
+		return out, err
+	}
+	if err = json.Unmarshal(raw, &out); err != nil {
+		return out, err
+	}
+	if err = out.Validate(); err != nil {
+		return out, err
+	}
+	return out, nil
+}

--- a/go/pkg/database/database_test.go
+++ b/go/pkg/database/database_test.go
@@ -42,3 +42,43 @@ func TestDBPutBlockInvalid(t *testing.T) {
 		t.Fatalf("expected error")
 	}
 }
+
+func TestDBListBlocks(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(dir)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+
+	mkblk := func(v int) coin.Block {
+		tx := coin.Transaction{Version: uint32(v)}
+		b := coin.Block{Header: coin.BlockHeader{Version: 1}, Transactions: []coin.Transaction{tx}}
+		b.Header.MerkleRoot = b.BuildMerkleRoot()
+		return b
+	}
+
+	b1 := mkblk(1)
+	b2 := mkblk(2)
+	if err := db.PutBlock(b1); err != nil {
+		t.Fatalf("put1: %v", err)
+	}
+	if err := db.PutBlock(b2); err != nil {
+		t.Fatalf("put2: %v", err)
+	}
+
+	blocks, err := db.ListBlocks()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(blocks) != 2 {
+		t.Fatalf("expected 2 blocks, got %d", len(blocks))
+	}
+	seen := make(map[string]bool)
+	for _, b := range blocks {
+		seen[b.Header.Hash()] = true
+	}
+	if !seen[b1.Header.Hash()] || !seen[b2.Header.Hash()] {
+		t.Fatalf("missing blocks")
+	}
+}

--- a/go/pkg/database/database_test.go
+++ b/go/pkg/database/database_test.go
@@ -1,0 +1,44 @@
+package database
+
+import (
+	"testing"
+
+	"pila/pkg/coin"
+)
+
+func TestDBPutGetBlock(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(dir)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+
+	tx := coin.Transaction{Version: 1}
+	blk := coin.Block{Header: coin.BlockHeader{Version: 1}, Transactions: []coin.Transaction{tx}}
+	blk.Header.MerkleRoot = blk.BuildMerkleRoot()
+	if err := db.PutBlock(blk); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	out, err := db.GetBlock(blk.Header.Hash())
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if out.Header.Hash() != blk.Header.Hash() {
+		t.Fatalf("mismatch: %s != %s", out.Header.Hash(), blk.Header.Hash())
+	}
+}
+
+func TestDBPutBlockInvalid(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(dir)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+
+	blk := coin.Block{Header: coin.BlockHeader{Version: 1}}
+	if err := db.PutBlock(blk); err == nil {
+		t.Fatalf("expected error")
+	}
+}


### PR DESCRIPTION
## Summary
- detect duplicate transactions in `Block.Validate`
- validate blocks when storing or loading from DB
- extend block and database tests to cover new checks

## Testing
- `go test ./...`
- `go run ./cmd/pila`


------
https://chatgpt.com/codex/tasks/task_e_68530b8a7e10832384bd4f245ec005a8